### PR TITLE
Migrate audio concatenation to use ffmpeg

### DIFF
--- a/backend/app/services/video/transitions_service.py
+++ b/backend/app/services/video/transitions_service.py
@@ -21,7 +21,11 @@ blur, and warp effects.
 """
 
 import cv2
+import logging
 import numpy as np
+import subprocess
+import tempfile
+import os
 from moviepy import editor
 from scipy import ndimage
 
@@ -45,6 +49,54 @@ class TransitionsService:
     initialization arguments.
     """
     pass
+
+  def concatenate_audioclips(self, audioclip1_filename, audioclip2_filename, audioclip1_duration=None):
+      """
+      Trims the end of clip1, then concatenates clip1 and clip2 audio using ffmpeg's concat demuxer.
+
+      Args:
+          file1 (str): Path to first audio file.
+          file2 (str): Path to second audio file.
+          audioclip1_duration (float): If the first audioclip should be trimmed, the duration of that clip.
+
+      Returns:
+          str: Path to output audio file.
+      """
+      with tempfile.TemporaryDirectory() as tmpdir:
+          audioclip1_to_use = audioclip1_filename
+
+          # If audioclip1_duration is not provided, use the full length of the first audio file.
+          if audioclip1_duration is not None:
+            trimmed_audioclip1 = os.path.join(tmpdir, "trimmed_audioclip.mp4")
+            subprocess.run([
+                "ffmpeg", "-y",
+                "-i", audioclip1_filename,
+                "-t", str(audioclip1_duration),  # Trim to this duration.
+                "-c", "copy", # Copy the audio codec without re-encoding.
+                trimmed_audioclip1
+            ], check=True)
+            audioclip1_to_use = trimmed_audioclip1
+
+          # Create a file list for the concat demuxer.
+          file_list_path = os.path.join(tmpdir, "concat_list.txt")
+          with open(file_list_path, "w") as f:
+              f.write(f"file '{os.path.abspath(audioclip1_to_use)}'\n")
+              f.write(f"file '{os.path.abspath(audioclip2_filename)}'\n")
+
+          # Run ffmpeg concat.
+          output_audioclip = tempfile.NamedTemporaryFile(delete=False, suffix=".mp4")
+          output_audioclip.close()
+
+          subprocess.run([
+              "ffmpeg", "-y",
+              "-f", "concat",
+              "-safe", "0", # Allow "unsafe" file paths (absolute paths).
+              "-i", file_list_path,
+              "-c", "copy", # Copy the audio codec without re-encoding.
+              output_audioclip.name
+          ], check=True)
+
+          return output_audioclip.name
 
   def crossfade(self, clip1, clip2, transition_duration, speed_curve="sigmoid"):
     """
@@ -131,10 +183,7 @@ class TransitionsService:
     final_clip = editor.CompositeVideoClip([clip1, clip2], use_bgclip=True)
     final_clip = final_clip.set_make_frame(make_frame)
     final_clip = final_clip.set_duration(total_duration)
-    clip2_audio = editor.AudioFileClip(clip2.filename)
-    clip1_audio = editor.AudioFileClip(clip1.filename)
-    clip1_audio= clip1_audio.subclip(0, transition_start)
-    final_clip = final_clip.set_audio(editor.concatenate_audioclips([clip1_audio, clip2_audio]))
+    final_clip = final_clip.set_audio(editor.AudioFileClip(self.concatenate_audioclips(clip1.filename, clip2.filename, transition_start)))
 
     return final_clip
 
@@ -240,11 +289,7 @@ class TransitionsService:
         [clip2, clip1_masked], size=clip1.size
     )
     final_clip = final_clip.set_duration(total_duration)
-
-    clip2_audio = editor.AudioFileClip(clip2.filename)
-    clip1_audio = editor.AudioFileClip(clip1.filename)
-    clip1_audio= clip1_audio.subclip(0, transition_start)
-    final_clip = final_clip.set_audio(editor.concatenate_audioclips([clip1_audio, clip2_audio]))
+    final_clip = final_clip.set_audio(editor.AudioFileClip(self.concatenate_audioclips(clip1.filename, clip2.filename, transition_start)))
 
     return final_clip
 
@@ -419,11 +464,7 @@ class TransitionsService:
         size=clip1.size,
     )
     final_clip = final_clip.set_duration(total_duration)
-
-    clip2_audio = editor.AudioFileClip(clip2.filename)
-    clip1_audio = editor.AudioFileClip(clip1.filename)
-    clip1_audio= clip1_audio.subclip(0, transition_start)
-    final_clip = final_clip.set_audio(editor.concatenate_audioclips([clip1_audio, clip2_audio]))
+    final_clip = final_clip.set_audio(editor.AudioFileClip(self.concatenate_audioclips(clip1.filename, clip2.filename, transition_start)))
 
     return final_clip
 
@@ -648,11 +689,7 @@ class TransitionsService:
         size=clip1.size,
     )
     final_clip = final_clip.set_duration(total_duration)
-
-    clip2_audio = editor.AudioFileClip(clip2.filename)
-    clip1_audio = editor.AudioFileClip(clip1.filename)
-    clip1_audio= clip1_audio.subclip(0, transition_start)
-    final_clip = final_clip.set_audio(editor.concatenate_audioclips([clip1_audio, clip2_audio]))
+    final_clip = final_clip.set_audio(editor.AudioFileClip(self.concatenate_audioclips(clip1.filename, clip2.filename, transition_start)))
 
     return final_clip
 
@@ -751,10 +788,7 @@ class TransitionsService:
         [black_clip, clip1_fadeout, clip2_fadein]
     )
 
-    clip2_audio = editor.AudioFileClip(clip2.filename)
-    clip1_audio = editor.AudioFileClip(clip1.filename)
-    #clip1_audio= clip1_audio.subclip(0, transition_start)
-    final_clip = final_clip.set_audio(editor.concatenate_audioclips([clip1_audio, clip2_audio]))
+    final_clip = final_clip.set_audio(editor.AudioFileClip(self.concatenate_audioclips(clip1.filename, clip2.filename)))
 
     return final_clip
 
@@ -822,9 +856,8 @@ class TransitionsService:
 
     # Concatenate the (potentially trimmed) clips.
     final_clip = editor.concatenate_videoclips([clip1, clip2])
-    clip2_audio = editor.AudioFileClip(clip2.filename)
-    clip1_audio = editor.AudioFileClip(clip1.filename)
-    final_clip = final_clip.set_audio(editor.concatenate_audioclips([clip1_audio, clip2_audio]))
+    concatenated_audio = self.concatenate_audioclips(clip1.filename, clip2.filename)
+    final_clip = final_clip.set_audio(editor.AudioFileClip(concatenated_audio))
 
     return final_clip
 
@@ -972,9 +1005,7 @@ class TransitionsService:
 
     # Concatenate the blurred clips.
     final_clip = editor.concatenate_videoclips([clip1_blurred, clip2_blurred])
-    clip2_audio = editor.AudioFileClip(clip2.filename)
-    clip1_audio = editor.AudioFileClip(clip1.filename)
-    final_clip = final_clip.set_audio(editor.concatenate_audioclips([clip1_audio, clip2_audio]))
+    final_clip = final_clip.set_audio(editor.AudioFileClip(self.concatenate_audioclips(clip1.filename, clip2.filename)))
 
     return final_clip
 
@@ -1065,9 +1096,7 @@ class TransitionsService:
         blurred_frame2,  # second frame with zoom and 50% blur.
         clip2,  # clip2 unchanged.
     ])
-    clip2_audio = editor.AudioFileClip(clip2.filename)
-    clip1_audio = editor.AudioFileClip(clip1.filename)
-    final_clip = final_clip.set_audio(editor.concatenate_audioclips([clip1_audio, clip2_audio]))
+    final_clip = final_clip.set_audio(editor.AudioFileClip(self.concatenate_audioclips(clip1.filename, clip2.filename)))
 
     return final_clip
 
@@ -1170,11 +1199,7 @@ class TransitionsService:
 
     # Create a new clip with the custom frame-making function.
     final_clip = editor.VideoClip(make_frame, duration=total_duration)
-
-    clip2_audio = editor.AudioFileClip(clip2.filename)
-    clip1_audio = editor.AudioFileClip(clip1.filename)
-    clip1_audio= clip1_audio.subclip(0, clip1.duration - duration)
-    final_clip = final_clip.set_audio(editor.concatenate_audioclips([clip1_audio, clip2_audio]))
+    final_clip = final_clip.set_audio(editor.AudioFileClip(self.concatenate_audioclips(clip1.filename, clip2.filename, clip1.duration - duration)))
     return final_clip
 
   def slide_warp(
@@ -1323,10 +1348,7 @@ class TransitionsService:
 
     # Create a new clip with the custom frame-making function.
     final_clip = editor.VideoClip(make_frame, duration=total_duration)
-
-    clip2_audio = editor.AudioFileClip(clip2.filename)
-    clip1_audio = editor.AudioFileClip(clip1.filename)
-    clip1_audio= clip1_audio.subclip(0, clip1.duration - duration)
-    final_clip = final_clip.set_audio(editor.concatenate_audioclips([clip1_audio, clip2_audio]))
+    final_clip = final_clip.set_audio(editor.AudioFileClip(self.concatenate_audioclips(clip1.filename, clip2.filename, clip1.duration - duration)))
 
     return final_clip
+

--- a/backend/app/services/video/transitions_service.py
+++ b/backend/app/services/video/transitions_service.py
@@ -21,7 +21,6 @@ blur, and warp effects.
 """
 
 import cv2
-import logging
 import numpy as np
 import subprocess
 import tempfile


### PR DESCRIPTION
Concatenate audio in the transitions service using ffmpeg concat demuxer instead of MoviePy's concatenate_audiofiles (which was occasionally experiencing the following error: "index -100001 is out of bounds for axis 0 with size 0. Please try again."). 