### PR TITLE
Update model to use Imagen 4 GA version

### DIFF
--- a/backend/app/models/request_models.py
+++ b/backend/app/models/request_models.py
@@ -64,7 +64,7 @@ class CreativeDirection(BaseModel):
   """
 
   aspect_ratio: str | None = "1:1"
-  model: str = "imagen-4.0-generate-preview-06-06"
+  model: str = "imagen-4.0-generate-001"
   number_of_images: int | None = 1
   output_mime_type: Optional[str] | None = "image/png"
   person_generation: str | None = "allow_adult"


### PR DESCRIPTION
As of 14-Aug-2025, Imagen 4 is now Generally Available and so the GA model version should probably be used?

https://cloud.google.com/vertex-ai/generative-ai/docs/models/imagen/4-0-generate-001