### PR TITLE
Update model to use Veo 3 GA version

### DIFF
--- a/backend/app/services/video/veo_api_service.py
+++ b/backend/app/services/video/veo_api_service.py
@@ -30,8 +30,7 @@ from google.genai.types import GenerateVideosConfig, Image, HttpOptions, Generat
 from models.video import video_request_models
 from models.video.video_gen_models import Video, VideoGenerationResponse
 
-DEFAULT_MODEL_NAME = "veo-3.0-generate-preview"
-# "veo-2.0-generate-001"
+DEFAULT_MODEL_NAME = "veo-3.0-generate-001"
 
 
 class VeoAPIService:


### PR DESCRIPTION
As of 08-Sep-2025, Veo is now Generally Available and so the GA model version should probably be used?

https://cloud.google.com/vertex-ai/generative-ai/docs/models/veo/3-0-generate-001